### PR TITLE
fix: rename publilishEvent to publishEvent across codebase

### DIFF
--- a/BUILDER_IMAGES/build-image-backend/publisher.js
+++ b/BUILDER_IMAGES/build-image-backend/publisher.js
@@ -10,7 +10,7 @@ const sns = new SNSClient({
 
 const TOPIC_ARN = process.env.DOMAIN_EVENTS_TOPIC_ARN;
 
-async function publilishEvent(type, projectId, deploymentId, payload) {
+async function publishEvent(type, projectId, deploymentId, payload) {
   await sns.send(
     new PublishCommand({
       TopicArn: TOPIC_ARN,
@@ -27,9 +27,9 @@ async function publilishEvent(type, projectId, deploymentId, payload) {
   );
 }
 
-module.exports = { publilishEvent };
+module.exports = { publishEvent };
 
 
-console.log("publilishEvent type:", typeof publilishEvent);
+console.log("publishEvent type:", typeof publishEvent);
 
-module.exports = { publilishEvent };
+module.exports = { publishEvent };

--- a/BUILDER_IMAGES/build-image-backend/script.js
+++ b/BUILDER_IMAGES/build-image-backend/script.js
@@ -154,7 +154,7 @@ async function init() {
                 "BUILD",
                 `Image build failed with code: ${code}`
             );
-            publishEvent("BACKEND_BUILD_FAILED", PROJECT_ID, DEPLOYMENTID, { msg: "Image build failed with code: ${code}" })
+            publishEvent("BACKEND_BUILD_FAILED", PROJECT_ID, DEPLOYMENTID, { msg: `Image build failed with code: ${code}` })
             await safeExit(code, "Build failed");
         }
     });

--- a/BUILDER_IMAGES/build-image-backend/script.js
+++ b/BUILDER_IMAGES/build-image-backend/script.js
@@ -2,7 +2,7 @@ const { spawn } = require("child_process")
 const path = require("path");
 const fs = require("fs")
 const { Kafka } = require("kafkajs");
-const { publilishEvent } = require("./publisher");
+const { publishEvent } = require("./publisher");
 
 const PROJECT_ID = process.env.PROJECT_ID;
 const ECR_URI = process.env.ECR_URI;
@@ -85,7 +85,7 @@ async function init() {
         throw new Error(`Build context path does not exist: ${buildContext}`);
     }
 
-    publilishEvent("BACKEND_PROCESSING", PROJECT_ID, DEPLOYMENTID, { backendDir: BACKEND_DIR })
+    publishEvent("BACKEND_PROCESSING", PROJECT_ID, DEPLOYMENTID, { backendDir: BACKEND_DIR })
 
 
     if (!NODE_VERSION) {
@@ -154,7 +154,7 @@ async function init() {
                 "BUILD",
                 `Image build failed with code: ${code}`
             );
-            publilishEvent("BACKEND_BUILD_FAILED", PROJECT_ID, DEPLOYMENTID, { msg: "Image build failed with code: ${code}" })
+            publishEvent("BACKEND_BUILD_FAILED", PROJECT_ID, DEPLOYMENTID, { msg: "Image build failed with code: ${code}" })
             await safeExit(code, "Build failed");
         }
     });
@@ -163,7 +163,7 @@ async function init() {
 init().catch(err => {
     console.log("INIT ERROR ", err);
     publishLog("FAILURE", "INIT", err.message)
-    publilishEvent("BACKEND_BUILD_FAILED", PROJECT_ID, DEPLOYMENTID, { msg: err.message })
+    publishEvent("BACKEND_BUILD_FAILED", PROJECT_ID, DEPLOYMENTID, { msg: err.message })
         .finally(() => safeExit(1, "Build Init Failed"));
 });;
 

--- a/BUILDER_IMAGES/builder-image-frontend/publisher.js
+++ b/BUILDER_IMAGES/builder-image-frontend/publisher.js
@@ -9,7 +9,7 @@ const sns = new SNSClient({
 
 const TOPIC_ARN = process.env.DOMAIN_EVENTS_TOPIC_ARN;
 
-async function publilishEvent(type, projectId, deploymentId, payload) {
+async function publishEvent(type, projectId, deploymentId, payload) {
     await sns.send(
         new PublishCommand({
             TopicArn: TOPIC_ARN,
@@ -23,4 +23,4 @@ async function publilishEvent(type, projectId, deploymentId, payload) {
     )
 }
 
-module.exports = { publilishEvent };
+module.exports = { publishEvent };

--- a/BUILDER_IMAGES/builder-image-frontend/script.js
+++ b/BUILDER_IMAGES/builder-image-frontend/script.js
@@ -5,7 +5,7 @@ const mime = require("mime-types");
 const readDirRecursive = require("./utils/readDirRecursive");
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 const { Kafka } = require("kafkajs");
-const { publilishEvent } = require("./publisher");
+const { publishEvent } = require("./publisher");
 
 /* ---------------- ENV ---------------- */
 
@@ -75,7 +75,7 @@ async function publishLog(level, stage, message) {
         }),
       },
     ],
-  }).catch(() => {});
+  }).catch(() => { });
 }
 
 /* ---------------- SAFE EXIT ---------------- */
@@ -90,7 +90,7 @@ async function safeExit(code, reason) {
       await publishLog("INFO", "SHUTDOWN", reason);
     }
     await producer.disconnect();
-  } catch (_) {}
+  } catch (_) { }
   finally {
     process.exit(code);
   }
@@ -104,7 +104,7 @@ process.on("SIGTERM", () => safeExit(143, "SIGTERM"));
 async function init() {
   await producer.connect();
 
-  await publilishEvent(
+  await publishEvent(
     "FRONTEND_PROCESSING",
     PROJECT_ID,
     DEPLOYMENTID,
@@ -117,7 +117,7 @@ async function init() {
   const frontendPath = path.join(outputDir, FRONTENDPATH || ".");
 
   if (!fs.existsSync(frontendPath)) {
-    await publilishEvent(
+    await publishEvent(
       "FRONTEND_BUILT_FAILED",
       PROJECT_ID,
       DEPLOYMENTID,
@@ -138,7 +138,7 @@ async function init() {
 
   build.on("close", async (code) => {
     if (code !== 0) {
-      await publilishEvent(
+      await publishEvent(
         "FRONTEND_BUILT_FAILED",
         PROJECT_ID,
         DEPLOYMENTID,
@@ -168,7 +168,7 @@ async function init() {
         }));
       }
 
-      await publilishEvent(
+      await publishEvent(
         "FRONTEND_BUILT_SUCCESS",
         PROJECT_ID,
         DEPLOYMENTID,
@@ -179,7 +179,7 @@ async function init() {
       await safeExit(0, "Success");
 
     } catch (err) {
-      await publilishEvent(
+      await publishEvent(
         "FRONTEND_BUILT_FAILED",
         PROJECT_ID,
         DEPLOYMENTID,
@@ -191,7 +191,7 @@ async function init() {
 }
 
 init().catch(async (err) => {
-  await publilishEvent(
+  await publishEvent(
     "FRONTEND_BUILT_FAILED",
     PROJECT_ID,
     DEPLOYMENTID,
@@ -203,7 +203,7 @@ init().catch(async (err) => {
 /* ---------------- TIMEOUT ---------------- */
 
 setTimeout(async () => {
-  await publilishEvent(
+  await publishEvent(
     "FRONTEND_BUILT_FAILED",
     PROJECT_ID,
     DEPLOYMENTID,

--- a/WORKERS/build-worker/src/services/distributionHandler/buildBackend.ts
+++ b/WORKERS/build-worker/src/services/distributionHandler/buildBackend.ts
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 import { AwsCredentialIdentity } from "@aws-sdk/types";
 import { ECSClient, RunTaskCommand } from "@aws-sdk/client-ecs";
 import { backendECSConfig } from "../../config/ECSconfig.js"
-import { DeploymentStatus, publilishEvent } from "@veren/domain";
+import { DeploymentStatus, publishEvent } from "@veren/domain";
 
 dotenv.config({
     path: '../../../.env'
@@ -90,7 +90,7 @@ export async function buildBackend(
 
     const resp = await ecsClient.send(backendCommand)
     if (resp.failures && resp.failures.length > 0) {
-        publilishEvent({
+        publishEvent({
             type: DeploymentStatus.INTERNAL_ERROR,
             projectId,
             deploymentId,

--- a/WORKERS/build-worker/src/services/distributionHandler/buildFrontend.ts
+++ b/WORKERS/build-worker/src/services/distributionHandler/buildFrontend.ts
@@ -4,7 +4,7 @@ import { AwsCredentialIdentity } from "@aws-sdk/types";
 
 import dotenv from "dotenv";
 import logger from "../../logger/logger.js";
-import { DeploymentStatus, publilishEvent } from '@veren/domain';
+import { DeploymentStatus, publishEvent } from '@veren/domain';
 
 dotenv.config({
     path: '../../../.env'
@@ -119,7 +119,7 @@ export async function buildFrontend(
 
         const resp = await ecsClient.send(command18)
         if (resp.failures && resp.failures.length > 0) {
-            publilishEvent({
+            publishEvent({
                 type: DeploymentStatus.INTERNAL_ERROR,
                 projectId,
                 deploymentId,
@@ -161,7 +161,7 @@ export async function buildFrontend(
 
         const resp = await ecsClient.send(command20)
         if (resp.failures && resp.failures.length > 0) {
-            publilishEvent({
+            publishEvent({
                 type: DeploymentStatus.INTERNAL_ERROR,
                 projectId,
                 deploymentId,

--- a/WORKERS/build-worker/src/workers/build.ts
+++ b/WORKERS/build-worker/src/workers/build.ts
@@ -7,7 +7,7 @@ import { buildFrontend } from "../services/distributionHandler/buildFrontend.js"
 import { buildBackend } from "../services/distributionHandler/buildBackend.js"
 import { safeExecute } from "../types/index.js";
 
-import { DeploymentStatus, publilishEvent } from '@veren/domain'
+import { DeploymentStatus, publishEvent } from '@veren/domain'
 import { BuildJobError } from "../utils/buildError.js";
 
 dotenv.config({ path: "../../.env" });
@@ -129,7 +129,7 @@ const worker = new Worker<BuildJobData, BuildJobResult>('buildQueue',
 worker.on('completed', async (job, result) => {
     const { projectId, deploymentId, FrontendtaskArn, BackendtaskArn } = result;
 
-    publilishEvent({
+    publishEvent({
         type: DeploymentStatus.BUILD_QUEUE_SUCCESS,
         projectId: result.projectId,
         deploymentId: result.deploymentId,
@@ -147,21 +147,21 @@ worker.on('failed', async (job: any, err: any) => {
     });
     if (err instanceof BuildJobError) {
         if (err.message == "BACKEND_BUILT_FAILED") {
-            publilishEvent({
+            publishEvent({
                 type: DeploymentStatus.BACKEND_QUEUE_FAILED,
                 projectId: job?.data?.projectId!,
                 deploymentId: job?.data?.deploymentId!,
                 payload: err.payload,
             });
         } else if (err.message == "FRONTEND_BUILT_FAILED") {
-            publilishEvent({
+            publishEvent({
                 type: DeploymentStatus.FRONTEND_QUEUE_FAILED,
                 projectId: job?.data?.projectId!,
                 deploymentId: job?.data?.deploymentId!,
                 payload: err.payload,
             });
         } else {
-            publilishEvent({
+            publishEvent({
                 type: DeploymentStatus.BUILD_UNKNOWN_FAILURE,
                 projectId: job?.data?.projectId!,
                 deploymentId: job?.data?.deploymentId!,
@@ -169,7 +169,7 @@ worker.on('failed', async (job: any, err: any) => {
             });
         }
     } else {
-        publilishEvent({
+        publishEvent({
             type: DeploymentStatus.INTERNAL_ERROR,
             projectId: job?.data?.projectId!,
             deploymentId: job?.data?.deploymentId!,

--- a/WORKERS/clone-worker/src/workers/clone.ts
+++ b/WORKERS/clone-worker/src/workers/clone.ts
@@ -5,7 +5,7 @@ import fs from "fs/promises";
 import logger from "../logger/logger.js";
 import { cloneRepo } from "../GitHandler/gitHandler.js";
 import repoConfigGenerator, { IBuild } from "../services/repoConfigGenerator.js";
-import { DeploymentStatus, publilishEvent } from "@veren/domain";
+import { DeploymentStatus, publishEvent } from "@veren/domain";
 import { CloneJobError } from "../utils/JobError.js";
 
 /* ---------------- TYPES ---------------- */
@@ -19,7 +19,7 @@ interface CloneJobData {
     backendDirPath: string;
     frontendDirPath: string;
   };
-  build:IBuild;
+  build: IBuild;
 }
 
 interface CloneJobResult {
@@ -128,8 +128,8 @@ export const worker = new Worker<CloneJobData, CloneJobResult>(
       };
     } finally {
 
-    /* ---------- CLEAN FOLDER SPACE ---------- */
-    
+      /* ---------- CLEAN FOLDER SPACE ---------- */
+
       if (baseDir) {
         try {
           await fs.rm(baseDir, { recursive: true, force: true });
@@ -154,7 +154,7 @@ worker.on("completed", async (job, result) => {
     deploymentId: result.deploymentId,
   });
 
-  publilishEvent({
+  publishEvent({
     type: DeploymentStatus.REPO_ANALYSIS_SUCCESS,
     projectId: result.projectId,
     deploymentId: result.deploymentId,
@@ -173,14 +173,14 @@ worker.on("failed", async (job, err) => {
   });
 
   if (err instanceof CloneJobError) {
-    publilishEvent({
+    publishEvent({
       type: DeploymentStatus.REPO_ANALYSIS_FAILED,
       projectId: job?.data?.projectId!,
       deploymentId: job?.data?.deploymentId!,
       payload: err.payload,
     });
   } else {
-    publilishEvent({
+    publishEvent({
       type: DeploymentStatus.INTERNAL_ERROR,
       projectId: job?.data?.projectId!,
       deploymentId: job?.data?.deploymentId!,

--- a/api-gateway/src/controllers/auth.controller.ts
+++ b/api-gateway/src/controllers/auth.controller.ts
@@ -120,7 +120,7 @@ const getMe = asyncHandler(async (req: Request, res: Response) => {
     }
     let user = await User.findById(req.user.id).select(
         "name userName email avatar provider createdAt"
-    );;
+    );
 
     if (!user) {
         return res.status(404).json(

--- a/api-gateway/src/controllers/auth.controller.ts
+++ b/api-gateway/src/controllers/auth.controller.ts
@@ -121,7 +121,7 @@ const getMe = asyncHandler(async (req: Request, res: Response) => {
     let user = await User.findById(req.user.id).select(
         "name userName email avatar provider createdAt"
     );;
-    
+
     if (!user) {
         return res.status(404).json(
             new ApiResponse(404, null, "User not found")
@@ -133,35 +133,33 @@ const getMe = asyncHandler(async (req: Request, res: Response) => {
     );
 });
 
-const refreshAccessToken = asyncHandler(async (req:Request, res: Response)=>{
-    let incomingRefreshToken =req.cookies.refreshToken;
-    if(!incomingRefreshToken){
+const refreshAccessToken = asyncHandler(async (req: Request, res: Response) => {
+    let incomingRefreshToken = req.cookies.refreshToken;
+    if (!incomingRefreshToken) {
         throw new ApiError(401, "Refresh Token is required");
     }
 
     try {
         const decodedToken = jwt.verify(
-            incomingRefreshToken, 
+            incomingRefreshToken,
             process.env.REFRESH_TOKEN_SECRET!
-        ) as {tokenVersion: number, sub: string};
+        ) as { tokenVersion: number, sub: string };
 
         const user = await User.findById(decodedToken?.sub);
-        if(!user){
+        if (!user) {
             throw new ApiError(404, "Invalid refresh Token");
         }
 
-        if(decodedToken?.tokenVersion! != user?.tokenVersion){
+        if (decodedToken?.tokenVersion! != user?.tokenVersion) {
             throw new ApiError(404, "Invalid Refresh Token");
         }
 
-        const options = {
 
-        }
         const newRefreshToken = user.generateRefreshToken();
         const newAccessToken = user.generateAccessToken();
 
         setAuthCookies(res, newAccessToken, newRefreshToken);
-        res.status(200).json(new ApiResponse(200, {newAccessToken, newRefreshToken}, "Refresh token generated successfully"));
+        res.status(200).json(new ApiResponse(200, { newAccessToken, newRefreshToken }, "Refresh token generated successfully"));
     } catch (error) {
         throw new ApiError(404, "Failed to refresh refresh-token");
     }

--- a/api-gateway/src/controllers/deployment.controller.ts
+++ b/api-gateway/src/controllers/deployment.controller.ts
@@ -7,7 +7,7 @@ import { cloneQueue } from "../Queue/clone-queue.js";
 
 import logger from "../logger/logger.js";
 
-import { Project, DeploymentStatus, publilishEvent } from "@veren/domain";
+import { Project, DeploymentStatus, publishEvent } from "@veren/domain";
 import { Deployment } from "@veren/domain";
 
 
@@ -84,7 +84,7 @@ const deployProject = asyncHandler(async (req: Request, res: Response) => {
 
     logger.info(`Clone job added for project ${projectId}`);
 
-    publilishEvent({
+    publishEvent({
       type: DeploymentStatus.CREATED,
       projectId: projectId,
       deploymentId: newDeployment._id.toString(),

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -80,7 +80,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - clones-data:/src/build-worker/src/clones
     env_file:
-      - ./WORKERS//build-worker/.env
+      - ./WORKERS/build-worker/.env
     networks:
       - veren
     depends_on:

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -5,4 +5,4 @@ export { Project } from "./project.model.js"
 export type { IProject } from "./types/project.js";
 
 export { DeploymentStatus } from './enums.js'
-export { publilishEvent } from './publisher.js'
+export { publishEvent } from './publisher.js'

--- a/packages/domain/src/publisher.ts
+++ b/packages/domain/src/publisher.ts
@@ -10,7 +10,7 @@ const sns = new SNSClient({
 
 const TOPIC_ARN = process.env.DOMAIN_EVENTS_TOPIC_ARN!;
 
-export async function publilishEvent(event: {
+export async function publishEvent(event: {
     type: DeploymentStatusI;
     projectId: string;
     deploymentId: string;


### PR DESCRIPTION
## Summary
Fixed typo in function name `publilishEvent` → [publishEvent](cci:1://file:///c:/Users/kshit/.gemini/antigravity/playground/silver-expanse/veren/BUILDER_IMAGES/build-image-backend/publisher.js:12:0-27:1) across the codebase.

## Changes
- Renamed function in 11 files (38+ usages)
- Fixed docker-compose.dev.yml double slash path
- Removed unused `options` variable in auth.controller.ts

## Verification
- Grep search confirms zero remaining typos